### PR TITLE
Implementation of repository management. Closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ Windows is known to work, but this cookbook does not have test kitchen coverage 
 * `node['homebrew']['taps']`: This attribute is used to install [Homebrew Taps](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.mdh/), the default method for installing "packages repositories" on OS X with this cookbook. It is used when including the `homebrew::install_taps` recipe, which is done by default in this cookbook's `mac_os_x` recipe. The value should be specified as an Array of [tap names](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Interesting-Taps-%26-Branches.md).
 * `node['packages']`: This attribute is used to install OS packages on Linux using the native package manager. It is used when including the `packages` recipe, which is done by default in this cookbook's non-OS X [recipes (`windows`, `debian` and `rhel`)](#bugs). The value should be specified as an Array of package names that are available from the distribution's package repositories.
 * `node['chocolatey']['packages']`: This attribute is used to install [Chocolatey packages](https://chocolatey.org/), the recommended method for installing "packages" on Windows with this cookbook. It is used in the `windows` recipe, which is included by default on `windows` platform systems. The value should be specified as an Array of chocolatey [package names](https://chocolatey.org/packages).
+* `node['pantry']['repositories']`: This attribute is used to git clone various repositories locally. It is used when including the `repositories` recipe, which is done by default in `pantry::default`. The value should be specified as a Hash as follows:
+    "repositories": {
+      "pantry-cookbook": {
+        "source": "https://github.com/opscode-cookbooks/pantry.git",
+        "destination": "~/src/cookbooks/pantry"
+      }
+    }
+* `node['pantry']['user']`: This attribute is required when running `pantry::repositories` and is the user under which the repository will be cloned.
+* `node['pantry']['group']`: This attribute is required when running `pantry::repositories` and is the group under which the repository will be cloned.
 
 **Note** Linux platforms are not officially supported by Pantry yet and things may work with or without modification.
 
@@ -41,7 +50,11 @@ Windows is known to work, but this cookbook does not have test kitchen coverage 
 
 ### default
 
-This recipe will include the node's platform-family recipe. For example, `mac_os_x`.
+This recipe will include the node's platform-family recipe. For example, `mac_os_x`. It will also include `pantry::repositories`.
+
+### repositories
+
+This recipe will run the `pantry_repository` resource against `node['pantry']['repositories']`.
 
 ## Bugs
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,3 +6,4 @@
 #
 
 default['chocolatey']['packages'] = []
+default['pantry']['repositories'] = {}

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -1,0 +1,102 @@
+use_inline_resources if defined?(:use_inline_resources)
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  if @current_resource.exists
+    Chef::Log.info "#{@new_resource} already exists - nothing to do."
+  else
+    converge_by("Create #{@new_resource}") do
+      dir = expand_directory_path(@new_resource.directory)
+      create_repository(dir)
+    end
+  end
+end
+
+action :delete do
+  if @current_resource.exists
+    converge_by("Delete #{@new_resource}") do
+      dir = expand_directory_path(@new_resource.directory)
+      delete_repository(dir)
+    end
+  else
+    Chef::Log.info "#{@current_resource} doesn't exist - can't delete."
+  end
+end
+
+def load_current_resource
+  directory = expand_directory_path(@new_resource.directory)
+  @current_resource = Chef::Resource::PantryRepository.new(@new_resource.name)
+  @current_resource.name(@new_resource.name)
+  @current_resource.group(@new_resource.group)
+  @current_resource.repository(@new_resource.repository)
+  @current_resource.user(@new_resource.user)
+  @current_resource.directory(directory)
+  @current_resource.exists = repository_exists?(@current_resource.directory)
+end
+
+def create_repository(dir)
+  subdirectories(dir).each do |subdirectory|
+    directory subdirectory do
+      action :create
+      user new_resource.user
+      group new_resource.group
+      recursive true
+    end
+  end
+
+  git directory do
+    action :checkout
+    group new_resource.group
+    repository new_resource.repository
+    revision 'master'
+    user new_resource.user
+  end
+
+  execute "checkout master on #{directory}" do
+    command 'git checkout master'
+    cwd     directory
+    user    new_resource.user
+    group   new_resource.group
+  end
+end
+
+def delete_repository(dir)
+  directory dir do
+    action :delete
+    recursive true
+    only_if { repository_exists?(dir) }
+  end
+end
+
+def repository_exists?(path)
+  Chef::Log.debug "Checking to see if this repository exists at path: '#{ path }'"
+  ::File.directory?("#{path}/.git")
+end
+
+def subdirectories(dir)
+  directories = []
+  dir.split('/').each_with_index do |value, index|
+    next if index == 0
+    if index == 1
+      directories.push(value)
+      next
+    end
+
+    subdirectory = [directories.last, value].join('/')
+    directories.push(subdirectory)
+  end
+
+  return directories.reject { |subdirectory| ::File.directory?(subdirectory) }
+end
+
+def expand_directory_path(path)
+  home_dir = ENV['HOME']
+  ENV['HOME'] = Dir.home(machine_user)
+  destination = ::File.expand_path(path)
+  ENV['HOME'] = home_dir
+
+  return destination
+end

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -47,7 +47,7 @@ def create_repository(dir)
     end
   end
 
-  git directory do
+  git dir do
     action :checkout
     group new_resource.group
     repository new_resource.repository
@@ -55,9 +55,9 @@ def create_repository(dir)
     user new_resource.user
   end
 
-  execute "checkout master on #{directory}" do
+  execute "checkout master on #{dir}" do
     command 'git checkout master'
-    cwd     directory
+    cwd     dir
     user    new_resource.user
     group   new_resource.group
   end

--- a/providers/repository.rb
+++ b/providers/repository.rb
@@ -9,7 +9,7 @@ action :create do
     Chef::Log.info "#{@new_resource} already exists - nothing to do."
   else
     converge_by("Create #{@new_resource}") do
-      dir = expand_directory_path(@new_resource.directory)
+      dir = expand_directory_path(@new_resource.directory, @new_resource.user)
       create_repository(dir)
     end
   end
@@ -18,7 +18,7 @@ end
 action :delete do
   if @current_resource.exists
     converge_by("Delete #{@new_resource}") do
-      dir = expand_directory_path(@new_resource.directory)
+      dir = expand_directory_path(@new_resource.directory, @new_resource.user)
       delete_repository(dir)
     end
   else
@@ -27,7 +27,7 @@ action :delete do
 end
 
 def load_current_resource
-  directory = expand_directory_path(@new_resource.directory)
+  directory = expand_directory_path(@new_resource.directory, @new_resource.user)
   @current_resource = Chef::Resource::PantryRepository.new(@new_resource.name)
   @current_resource.name(@new_resource.name)
   @current_resource.group(@new_resource.group)
@@ -92,7 +92,7 @@ def subdirectories(dir)
   return directories.reject { |subdirectory| ::File.directory?(subdirectory) }
 end
 
-def expand_directory_path(path)
+def expand_directory_path(path, machine_user)
   home_dir = ENV['HOME']
   ENV['HOME'] = Dir.home(machine_user)
   destination = ::File.expand_path(path)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,3 +6,4 @@
 #
 
 include_recipe "pantry::#{node['platform_family']}"
+include_recipe 'pantry::repositories'

--- a/recipes/repositories.rb
+++ b/recipes/repositories.rb
@@ -1,0 +1,7 @@
+node['pantry']['repositories'].each do |name, config|
+  pantry_repository config['destination'] do
+    repository config['source']
+    user node['pantry']['user']
+    group node['pantry']['group']
+  end
+end

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -1,0 +1,9 @@
+actions :create, :delete
+default_action :create
+
+attribute :directory, :default => nil, :kind_of => String, :name_attribute => true
+attribute :group, :default => nil, :kind_of => String
+attribute :repository, :default => nil, :kind_of => String
+attribute :user, :default => nil, :kind_of => String
+
+attr_accessor :exists


### PR DESCRIPTION
Note that we currently require `node.pantry.user` and `node.pantry.group` because the various operating systems have different ways of getting the user invoking sudo and there isn't a standard way of detecting what user/group should be when creating resources.

I'm open to making this a bit more automatic, though we'll need to handle cases such as the standard group on OS X being `staff` and not the same as the username.
